### PR TITLE
Additional fix based on suggestion from mhardin

### DIFF
--- a/src/test/java/com/rmn/qa/AutomationCapabilityMatcherTest.java
+++ b/src/test/java/com/rmn/qa/AutomationCapabilityMatcherTest.java
@@ -42,7 +42,7 @@ public class AutomationCapabilityMatcherTest {
         AutomationCapabilityMatcher matcher = new AutomationCapabilityMatcher();
         Map<String,Object> nodeCapability = new HashMap<String,Object>();
         nodeCapability.put(CapabilityType.BROWSER_NAME,"firefox");
-        nodeCapability.put(AutomationConstants.INSTANCE_ID,"foobar");
+        nodeCapability.put(AutomationConstants.INSTANCE_ID,"foo");
         Map<String,Object> testCapability = new HashMap<String,Object>();
         testCapability.put(CapabilityType.BROWSER_NAME,"firefox");
         AutomationDynamicNode node = new AutomationDynamicNode("uuid","id","browser","os", new Date(),10);
@@ -130,5 +130,7 @@ public class AutomationCapabilityMatcherTest {
     @After
     public void clearSystemProperty() {
         System.clearProperty(AutomationConstants.EXTRA_CAPABILITIES_PROPERTY_NAME);
+        // Also clear out the old AutomationRunContext
+        AutomationContext.refreshContext();
     }
 }

--- a/src/test/java/com/rmn/qa/task/AutomationReaperTaskTest.java
+++ b/src/test/java/com/rmn/qa/task/AutomationReaperTaskTest.java
@@ -4,6 +4,7 @@ import java.util.Arrays;
 import java.util.Calendar;
 import java.util.Date;
 
+import org.junit.After;
 import org.junit.Test;
 
 import com.amazonaws.services.ec2.model.Instance;
@@ -18,13 +19,18 @@ import junit.framework.Assert;
 
 public class AutomationReaperTaskTest {
 
+	@After
+    public void tearDown() {
+        AutomationContext.refreshContext();
+    }
+	
     @Test
     public void testShutdown() {
         MockVmManager ec2 = new MockVmManager();
         Reservation reservation = new Reservation();
         Instance instance = new Instance();
         instance.setState(new InstanceState().withCode(10));
-        String instanceId = "foobar";
+        String instanceId = "foo";
         instance.setInstanceId(instanceId);
         instance.setLaunchTime(AutomationUtils.modifyDate(new Date(),-5,Calendar.HOUR));
         reservation.setInstances(Arrays.asList(instance));


### PR DESCRIPTION
Undo renaming of instanceID and instead added cleanup of AutomationRunContext in @After method.