### PR TITLE
Improving ad-hoc scale logic

### DIFF
--- a/src/main/java/com/rmn/qa/AutomationDynamicNode.java
+++ b/src/main/java/com/rmn/qa/AutomationDynamicNode.java
@@ -35,7 +35,7 @@ public final class AutomationDynamicNode implements Comparable<AutomationDynamic
     private static final int NODE_INTERVAL_LIFETIME = 55; // 55 minutes
 
     // TODO: Refactor this to be AutomationRunRequest
-    private final String uuid, instanceId, browser, ipAddress;
+    private final String uuid, instanceId, browser, ipAddress, instanceType;
     private final Platform platform;
     private Date startDate,endDate;
     private final int nodeCapacity;
@@ -55,6 +55,10 @@ public final class AutomationDynamicNode implements Comparable<AutomationDynamic
     }
 
     public AutomationDynamicNode(String uuid,String instanceId,String browser, Platform platform, String ipAddress, Date startDate, int nodeCapacity){
+        this(uuid, instanceId, browser, platform, ipAddress, startDate, nodeCapacity, null);
+    }
+
+    public AutomationDynamicNode(String uuid,String instanceId,String browser, Platform platform, String ipAddress, Date startDate, int nodeCapacity, String instanceType){
         this.uuid = uuid;
         this.instanceId = instanceId;
         this.browser = browser;
@@ -63,6 +67,7 @@ public final class AutomationDynamicNode implements Comparable<AutomationDynamic
         this.startDate = startDate;
         this.endDate = computeEndDate(startDate);
         this.nodeCapacity = nodeCapacity;
+        this.instanceType = instanceType;
         this.status = STATUS.RUNNING;
     }
 
@@ -170,6 +175,14 @@ public final class AutomationDynamicNode implements Comparable<AutomationDynamic
      */
     public int getNodeCapacity() {
         return nodeCapacity;
+    }
+
+    /**
+     * Returns the instance type of this node
+     * @return
+     */
+    public String getInstanceType() {
+        return instanceType;
     }
 
     /**

--- a/src/main/java/com/rmn/qa/AutomationUtils.java
+++ b/src/main/java/com/rmn/qa/AutomationUtils.java
@@ -168,6 +168,9 @@ public final class AutomationUtils {
      * @return
      */
     public static Platform getUnderlyingFamily(Platform platform) {
+        if (platform == null) {
+            return null;
+        }
         if (platform == Platform.UNIX || platform == Platform.WINDOWS || platform == Platform.MAC || platform == Platform.ANY) {
             return platform;
         } else {

--- a/src/main/java/com/rmn/qa/aws/AwsTagReporter.java
+++ b/src/main/java/com/rmn/qa/aws/AwsTagReporter.java
@@ -11,6 +11,17 @@
  */
 package com.rmn.qa.aws;
 
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collection;
+import java.util.List;
+import java.util.Properties;
+import java.util.Set;
+
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import com.amazonaws.AmazonServiceException;
 import com.amazonaws.services.ec2.AmazonEC2Client;
 import com.amazonaws.services.ec2.model.CreateTagsRequest;
 import com.amazonaws.services.ec2.model.DescribeInstancesRequest;
@@ -18,15 +29,6 @@ import com.amazonaws.services.ec2.model.DescribeInstancesResult;
 import com.amazonaws.services.ec2.model.Instance;
 import com.amazonaws.services.ec2.model.Tag;
 import com.google.common.annotations.VisibleForTesting;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
-
-import java.util.ArrayList;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.List;
-import java.util.Properties;
-import java.util.Set;
 
 public class AwsTagReporter extends Thread {
 
@@ -67,7 +69,7 @@ public class AwsTagReporter extends Thread {
                     instancesFound = true;
                 }
             } catch(Throwable t) {
-                log.error("Error finding instances.  Sleeping.");
+                log.warn("Error finding instances.  Sleeping for 500ms.");
                 try {
                     sleep();
                 } catch (InterruptedException e) {
@@ -96,7 +98,7 @@ public class AwsTagReporter extends Thread {
                 setTagsForInstance(instanceId);
             }
             log.info("Tags added!");
-        } catch(IndexOutOfBoundsException | ClassCastException e) {
+        } catch(IndexOutOfBoundsException | ClassCastException | AmazonServiceException e) {
             log.error("Error adding tags.  Please make sure your tag syntax is correct (refer to the readme)",e);
         }
     }

--- a/src/main/java/com/rmn/qa/servlet/StatusServlet.java
+++ b/src/main/java/com/rmn/qa/servlet/StatusServlet.java
@@ -24,6 +24,7 @@ import javax.servlet.ServletException;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 
+import org.apache.commons.lang3.StringUtils;
 import org.openqa.grid.common.GridDocHelper;
 import org.openqa.grid.internal.Registry;
 import org.openqa.grid.internal.RemoteProxy;
@@ -133,6 +134,9 @@ public class StatusServlet extends RegistryBasedServlet {
                 AutomationDynamicNode node = AutomationContext.getContext().getNode((String)instanceId);
                 if(node != null) {
                     localBuilder.append("<br>EC2 dynamic node " + node.getInstanceId());
+                    if (!StringUtils.isEmpty(node.getInstanceType())) {
+                        localBuilder.append("<br>Instance Type " + node.getInstanceType());
+                    }
                     localBuilder.append("<br>Start time " + node.getStartDate());
                     localBuilder.append("<br>Current shutdown time ").append(node.getEndDate());
                     localBuilder.append("<br>Requested test run ").append(node.getUuid());

--- a/src/main/java/com/rmn/qa/task/AutomationPendingNodeRegistryTask.java
+++ b/src/main/java/com/rmn/qa/task/AutomationPendingNodeRegistryTask.java
@@ -24,6 +24,7 @@ import com.rmn.qa.AutomationContext;
 import com.rmn.qa.AutomationDynamicNode;
 import com.rmn.qa.AutomationRunContext;
 import com.rmn.qa.RegistryRetriever;
+import com.rmn.qa.aws.VmManager;
 
 /**
  * Registry task which registers dynamic {@link AutomationDynamicNode nodes} as they come online
@@ -35,14 +36,16 @@ public class AutomationPendingNodeRegistryTask extends AbstractAutomationCleanup
 	private static final Logger log = LoggerFactory.getLogger(AutomationPendingNodeRegistryTask.class);
 	@VisibleForTesting
 	static final String NAME = "Pending Node Registry Task";
+	private VmManager vmManager;
 
 	/**
 	 * Constructs a registry task with the specified context retrieval mechanism
 	 *
 	 * @param registryRetriever Represents the retrieval mechanism you wish to use
 	 */
-	public AutomationPendingNodeRegistryTask(RegistryRetriever registryRetriever) {
+	public AutomationPendingNodeRegistryTask(RegistryRetriever registryRetriever, VmManager vmManager) {
 		super(registryRetriever);
+		this.vmManager = vmManager;
 	}
 
 	/**
@@ -81,5 +84,7 @@ public class AutomationPendingNodeRegistryTask extends AbstractAutomationCleanup
 				}
 			}
 		}
+		// Remove any pending nodes that haven't come online after a configured amount of time
+		AutomationContext.getContext().removeExpiredPendingNodes(vmManager);
 	}
 }

--- a/src/main/java/com/rmn/qa/task/ScaleCapacityContext.java
+++ b/src/main/java/com/rmn/qa/task/ScaleCapacityContext.java
@@ -1,0 +1,47 @@
+package com.rmn.qa.task;
+
+import java.util.Collection;
+import java.util.Iterator;
+import java.util.List;
+
+import com.beust.jcommander.internal.Lists;
+import com.google.common.annotations.VisibleForTesting;
+import com.rmn.qa.AutomationContext;
+import com.rmn.qa.AutomationDynamicNode;
+
+/**
+ * Created by matthew on 6/23/16.
+ */
+public class ScaleCapacityContext {
+
+	@VisibleForTesting
+	List<AutomationDynamicNode> nodesPendingStartup = Lists.newArrayList();
+
+	public int getTotalCapacityCount() {
+		return nodesPendingStartup.stream().mapToInt(AutomationDynamicNode::getNodeCapacity).sum();
+	}
+
+	public void addAll(Collection<AutomationDynamicNode> nodes) {
+		nodesPendingStartup.addAll(nodes);
+	}
+
+	/**
+	 * Clears out any nodes that are no longer in the 'pending' state
+	 */
+	public void clearPendingNodes() {
+		Iterator<AutomationDynamicNode> iterator = nodesPendingStartup.iterator();
+		while(iterator.hasNext()) {
+			AutomationDynamicNode pendingNode = iterator.next();
+			if (!AutomationContext.getContext().pendingNodeExists(pendingNode.getInstanceId())) {
+				iterator.remove();
+			}
+		}
+	}
+
+	@Override
+	public String toString() {
+		return "ScaleCapacityContext{" +
+				"nodesPendingStartup=" + nodesPendingStartup +
+				'}';
+	}
+}

--- a/src/test/java/com/rmn/qa/task/AutomationScaleNodeTaskTest.java
+++ b/src/test/java/com/rmn/qa/task/AutomationScaleNodeTaskTest.java
@@ -1,7 +1,7 @@
 package com.rmn.qa.task;
 
 import java.util.Arrays;
-import java.util.Calendar;
+import java.util.Collections;
 import java.util.Date;
 
 import org.junit.Test;
@@ -10,7 +10,7 @@ import org.openqa.selenium.remote.CapabilityType;
 import org.openqa.selenium.remote.DesiredCapabilities;
 
 import com.rmn.qa.AutomationContext;
-import com.rmn.qa.AutomationUtils;
+import com.rmn.qa.AutomationDynamicNode;
 import com.rmn.qa.BaseTest;
 import com.rmn.qa.MockRequestMatcher;
 import com.rmn.qa.MockVmManager;
@@ -22,7 +22,21 @@ import junit.framework.Assert;
  */
 public class AutomationScaleNodeTaskTest extends BaseTest {
 
+
 	@Test
+	// Handle
+	public void testNoQueuedRequests() {
+		MockVmManager manageEc2 = new MockVmManager();
+		MockRequestMatcher matcher = new MockRequestMatcher();
+		matcher.setThreadsToReturn(10);
+		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
+		task.setDesiredCapabilities(Collections.emptyList());
+		task.run();
+		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
+	}
+
+	@Test
+	// Unsupported browser on a queued request should not result in any scaled capacity
 	public void testUnsupportedBrowserNoNodesStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -36,6 +50,7 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 	}
 
 	@Test
+	// If an unsupported platform is queued, no node should be started
 	public void testUnsupportedPlatformNoNodesStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -50,45 +65,7 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 	}
 
 	@Test
-	public void testNodesPendingStartupNoNodesStarted() {
-		MockVmManager manageEc2 = new MockVmManager();
-		MockRequestMatcher matcher = new MockRequestMatcher();
-		matcher.setThreadsToReturn(10);
-		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
-		DesiredCapabilities capabilities = new DesiredCapabilities();
-		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
-		capabilities.setPlatform(Platform.LINUX);
-		task.setDesiredCapabilities(Arrays.asList(capabilities));
-		String nodePendingStartup = "foo";
-		AutomationContext.getContext().addPendingNode(nodePendingStartup);
-		task.run();
-		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
-	}
-
-	@Test
-	public void testNodesPendingStartupExpire() {
-		MockVmManager manageEc2 = new MockVmManager();
-		MockRequestMatcher matcher = new MockRequestMatcher();
-		matcher.setThreadsToReturn(10);
-		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
-		DesiredCapabilities capabilities = new DesiredCapabilities();
-		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
-		capabilities.setPlatform(Platform.LINUX);
-		task.setDesiredCapabilities(Arrays.asList(capabilities));
-		String nodePendingStartup = "foo";
-		AutomationContext.getContext().addPendingNode(nodePendingStartup);
-		task.run();
-		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
-		task.nodeToCreation.put(nodePendingStartup, AutomationUtils.modifyDate(new Date(), -15, Calendar.MINUTE));
-		task.run();
-		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
-		Assert.assertFalse("Pending node should be cleared as enough time has elapsed", task.nodeToCreation.containsKey(nodePendingStartup));
-		task.run();
-		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
-	}
-
-	@Test
+	// Not sure if this will ever happen in the wild, but if no platform is specified, make sure we're defaulting to ANY
 	public void testNullPlatformNodeStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -99,13 +76,14 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		task.setDesiredCapabilities(Arrays.asList(capabilities));
 		task.run();
 		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(0));
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.ANY, task.getPlatformStarted().get(0));
 		Assert.assertEquals("Number of nodes started should be correct", 1, task.getNumThreadsStarted().get(0).intValue());
 	}
 
 	@Test
+	// If a queued request specifies ANY, we should handle starting up a new node
 	public void testAnyPlatformNodeStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -117,7 +95,7 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		task.setDesiredCapabilities(Arrays.asList(capabilities));
 		task.run();
 		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(0));
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.ANY, task.getPlatformStarted().get(0));
 		Assert.assertEquals("Number of nodes started should be correct", 1, task.getNumThreadsStarted().get(0).intValue());
@@ -138,14 +116,13 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		capabilities2.setCapability(CapabilityType.PLATFORM, Platform.UNIX);
 		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities2));
 		task.run();
-		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertEquals("Number of threads should be correct", 1, task.getNumThreadsStarted().size());
+		Assert.assertEquals("Nodes should have been started", 2, task.getNumThreadsStarted().get(0).intValue());
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.UNIX, task.getPlatformStarted().get(0));
-		Assert.assertEquals("Number of nodes started should be correct", 2, task.getNumThreadsStarted().get(0).intValue());
 	}
 	@Test
-	// If multiple requests have different platforms from the same family, only one type of platform should start
+	// If multiple requests have different platforms from different families, multiple types of nodes should start
 	public void testDifferentPlatformsStartDifferentNodes() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -160,10 +137,9 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities2));
 		task.run();
 		Assert.assertEquals("Nodes should have been started", 2, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(1));
-		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
-		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(1));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(1));
+		Assert.assertEquals("Started browser should be correct", 2, task.getBrowserStarted().stream().filter(browser -> "chrome".equals(browser)).count());
 		Assert.assertEquals("Started platform should be correct", 1, task.getPlatformStarted().stream().filter(platform -> platform == Platform.WINDOWS).count());
 		Assert.assertEquals("Started platform should be correct", 1, task.getPlatformStarted().stream().filter(platform -> platform == Platform.UNIX).count());
 		Assert.assertEquals("Number of nodes started should be correct", 1, task.getNumThreadsStarted().get(0).intValue());
@@ -171,6 +147,7 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 	}
 
 	@Test
+	// Happy path, make sure queued requests for linux result in started instances
 	public void testLinuxPlatformNodeStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -182,13 +159,98 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		task.setDesiredCapabilities(Arrays.asList(capabilities));
 		task.run();
 		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(0));
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.UNIX, task.getPlatformStarted().get(0));
 		Assert.assertEquals("Number of nodes started should be correct", 1, task.getNumThreadsStarted().get(0).intValue());
 	}
 
 	@Test
+	// Test that if there are nodes pending startup that haven't come online, their load is correctly factored into future
+	// scale activity
+	public void testPendingLoadSubtractsFromQueuedRequests() {
+		MockVmManager manageEc2 = new MockVmManager();
+		MockRequestMatcher matcher = new MockRequestMatcher();
+		matcher.setThreadsToReturn(10);
+		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
+		DesiredCapabilities capabilities = new DesiredCapabilities();
+		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
+		capabilities.setCapability(CapabilityType.PLATFORM, Platform.LINUX);
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
+		task.run();
+		Assert.assertEquals("Nodes should have been started", 2, task.getNodesStarted().size());
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities, capabilities, capabilities));
+		// Clear out previous counts from the mock task so they don't interfere with the new run
+		task.clear();
+		task.run();
+		Assert.assertEquals("Only 2 nodes should start as pending count should be subtracted from count", 2, task.getNodesStarted().size());
+	}
+
+	@Test
+	// Test that if there are nodes pending startup that haven't come online, their load is correctly factored into future
+	// scale activity
+	public void testUnrelatedPendingLoadDoesntSubtractsFromQueuedRequests() {
+		MockVmManager manageEc2 = new MockVmManager();
+		MockRequestMatcher matcher = new MockRequestMatcher();
+		matcher.setThreadsToReturn(10);
+		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
+		DesiredCapabilities capabilities = new DesiredCapabilities();
+		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
+		capabilities.setCapability(CapabilityType.PLATFORM, Platform.LINUX);
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
+		// Add 2 nodes to our pending context list and make sure this doesn't affect our scale node logic.  Only pending nodes that
+		// originate from AutomationScaleNodeTask should be included in the count
+		AutomationContext.getContext().addPendingNode(new AutomationDynamicNode(null, "foo", null, null, null, new Date(), 1));
+		AutomationContext.getContext().addPendingNode(new AutomationDynamicNode(null, "bar", null, null, null, new Date(), 1));
+		task.run();
+		Assert.assertEquals("Nodes should have been started", 2, task.getNodesStarted().size());
+	}
+
+	@Test
+	// Make sure after a node has registers with the hub, that it is no longer subtracted from scale activity
+	public void testPendingLoadDoesntSubtractsFromQueuedRequestsNodesStarted() {
+		MockVmManager manageEc2 = new MockVmManager();
+		MockRequestMatcher matcher = new MockRequestMatcher();
+		matcher.setThreadsToReturn(10);
+		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
+		DesiredCapabilities capabilities = new DesiredCapabilities();
+		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
+		capabilities.setCapability(CapabilityType.PLATFORM, Platform.LINUX);
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
+		task.run();
+		Assert.assertEquals("Nodes should have been started", 2, task.getNodesStarted().size());
+		// Clear all nodes from pending to emulate the nodes starting up
+		task.getNodesStarted().stream().forEach(node -> AutomationContext.getContext().removePendingNode(node.getInstanceId()));
+		// Clear out previous counts from the mock task so they don't interfere with the new run
+		task.clear();
+		task.run();
+		Assert.assertEquals("Only 2 nodes should start as pending count should be subtracted from count", 2, task.getNodesStarted().size());
+	}
+
+	@Test
+	// Make sure that nodes pending startup don't count towards other non-matching queued requests
+	public void testPendingLoadDoesntSubtractsFromQueuedRequests() {
+		MockVmManager manageEc2 = new MockVmManager();
+		MockRequestMatcher matcher = new MockRequestMatcher();
+		matcher.setThreadsToReturn(10);
+		MockAutomationScaleNodeTask task = new MockAutomationScaleNodeTask(null, manageEc2);
+		DesiredCapabilities capabilities = new DesiredCapabilities();
+		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
+		capabilities.setCapability(CapabilityType.PLATFORM, Platform.LINUX);
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
+		task.run();
+		Assert.assertEquals("Nodes should have been started", 2, task.getNodesStarted().size());
+		// Change the platform so we have different requests coming in
+		capabilities.setPlatform(Platform.WINDOWS);
+		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities, capabilities, capabilities));
+		// Clear out previous counts from the mock task so they don't interfere with the new run
+		task.clear();
+		task.run();
+		Assert.assertEquals("Only 2 nodes should start as pending count should be subtracted from count", 4, task.getNodesStarted().size());
+	}
+
+	@Test
+	// Make sure a higher specified platform dumbs down to its correct family (e.g. LINUX -> UNIX)
 	public void testFamilyPlatformNodeStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -200,13 +262,14 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		task.setDesiredCapabilities(Arrays.asList(capabilities));
 		task.run();
 		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertNotNull("Nodes should have been started", task.getNodesStarted().get(0));
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.UNIX, task.getPlatformStarted().get(0));
 		Assert.assertEquals("Number of nodes started should be correct", 1, task.getNumThreadsStarted().get(0).intValue());
 	}
 
 	@Test
+	// Tests that multiple queued requests result in multiple nodes started in one task pass
 	public void testMultipleNodesStartedAtOnce() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -217,14 +280,14 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		capabilities.setCapability(CapabilityType.PLATFORM, Platform.ANY);
 		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
 		task.run();
-		Assert.assertEquals("Nodes should have been started", 1, task.getNodesStarted().size());
-		Assert.assertTrue("Nodes should have been started", task.getNodesStarted().get(0));
+		Assert.assertEquals("Number of threads should be correct", 1, task.getNumThreadsStarted().size());
+		Assert.assertEquals("Nodes should have been started", 2, task.getNumThreadsStarted().get(0).intValue());
 		Assert.assertEquals("Started browser should be correct", "chrome", task.getBrowserStarted().get(0));
 		Assert.assertEquals("Started platform should be correct", Platform.ANY, task.getPlatformStarted().get(0));
-		Assert.assertEquals("Number of nodes started should be correct", 2, task.getNumThreadsStarted().get(0).intValue());
 	}
 
 	@Test
+	// Unsupported platform should not result in any scaled nodes
 	public void testUnsupportedPlatformNodeNotStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
@@ -239,7 +302,8 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 	}
 
 	@Test
-	public void testNotEnoughTimePassNoNewNodeStarted() {
+	// If a certain browser/platform hasn't been queued long enough, no nodes should be scaled up
+	public void testNotEnoughTimePassedNoNewNodeStarted() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
 		matcher.setThreadsToReturn(10);
@@ -253,7 +317,9 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 	}
 
 	@Test
-	public void testPendingBrowserDoesntMatchNoNewNodes() {
+	// Make sure if a previously tracked browser was seen by the task, that nothing starts up for that browser if there
+	// aren't any matching queued test requests
+	public void testPreviouslyTrackedBrowserDoesntStart() {
 		MockVmManager manageEc2 = new MockVmManager();
 		MockRequestMatcher matcher = new MockRequestMatcher();
 		matcher.setThreadsToReturn(10);
@@ -263,11 +329,17 @@ public class AutomationScaleNodeTaskTest extends BaseTest {
 		capabilities.setCapability(CapabilityType.BROWSER_NAME, "chrome");
 		task.setDesiredCapabilities(Arrays.asList(capabilities, capabilities));
 		task.run();
+		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
 		task.setNodeOldEnoughToStart(true);
 		DesiredCapabilities nonMatchingBrowser = new DesiredCapabilities();
 		nonMatchingBrowser.setBrowserName("firefox");
-		task.setDesiredCapabilities(Arrays.asList(nonMatchingBrowser));
-		Assert.assertEquals("No nodes should have been started", 0, task.getNodesStarted().size());
+		task.setDesiredCapabilities(Arrays.asList(nonMatchingBrowser, nonMatchingBrowser));
+		task.run();
+		// Firefox, not chrome, should start up
+		Assert.assertEquals("Number of threads should be correct", 1, task.getNumThreadsStarted().size());
+		Assert.assertEquals("Nodes should have been started", 2, task.getNumThreadsStarted().get(0).intValue());
+		Assert.assertEquals("Started browser should be correct", "firefox", task.getBrowserStarted().get(0));
+		Assert.assertEquals("Started platform should be correct", Platform.ANY, task.getPlatformStarted().get(0));
 	}
 
 

--- a/src/test/java/com/rmn/qa/task/MockAutomationPendingNodeRegistryTask.java
+++ b/src/test/java/com/rmn/qa/task/MockAutomationPendingNodeRegistryTask.java
@@ -3,6 +3,8 @@ package com.rmn.qa.task;
 import org.openqa.grid.internal.ProxySet;
 
 import com.rmn.qa.RegistryRetriever;
+import com.rmn.qa.aws.MockManageVm;
+import com.rmn.qa.aws.VmManager;
 
 /**
  * Created by matthew on 3/18/16.
@@ -12,7 +14,11 @@ public class MockAutomationPendingNodeRegistryTask extends AutomationPendingNode
 	private ProxySet proxySet;
 
 	public MockAutomationPendingNodeRegistryTask(RegistryRetriever registryRetriever) {
-		super(registryRetriever);
+		super(registryRetriever, new MockManageVm());
+	}
+
+	public MockAutomationPendingNodeRegistryTask(RegistryRetriever registryRetriever, VmManager vmManager) {
+		super(registryRetriever, vmManager);
 	}
 
 	@Override

--- a/src/test/java/com/rmn/qa/task/ScaleCapacityContextTest.java
+++ b/src/test/java/com/rmn/qa/task/ScaleCapacityContextTest.java
@@ -1,0 +1,53 @@
+package com.rmn.qa.task;
+
+import java.util.Date;
+
+import org.junit.Test;
+
+import com.beust.jcommander.internal.Lists;
+import com.rmn.qa.AutomationContext;
+import com.rmn.qa.AutomationDynamicNode;
+import com.rmn.qa.BaseTest;
+
+import junit.framework.Assert;
+
+/**
+ * Created by matthew on 3/18/16.
+ */
+public class ScaleCapacityContextTest extends BaseTest {
+
+	@Test
+	public void testCapacityCount() {
+		ScaleCapacityContext context = new ScaleCapacityContext();
+		AutomationDynamicNode firstNode = new AutomationDynamicNode(null, "foo", null, null, new Date(), 1);
+		AutomationDynamicNode secondNode = new AutomationDynamicNode(null, "bar", null, null, new Date(), 3);
+		int expectedCount = firstNode.getNodeCapacity() + secondNode.getNodeCapacity();
+		context.addAll(Lists.newArrayList(firstNode, secondNode));
+		Assert.assertEquals("Total capacity count should be correct", expectedCount, context.getTotalCapacityCount());
+	}
+
+	@Test
+	public void clearPendingNodes() {
+		ScaleCapacityContext context = new ScaleCapacityContext();
+		AutomationDynamicNode firstNode = new AutomationDynamicNode(null, "foo", null, null, new Date(), 1);
+		AutomationDynamicNode secondNode = new AutomationDynamicNode(null, "bar", null, null, new Date(), 1);
+		context.addAll(Lists.newArrayList(firstNode, secondNode));
+		Assert.assertEquals("Size should be correct as nodes should exist in context", 2, context.nodesPendingStartup.size());
+		context.clearPendingNodes();
+		Assert.assertEquals("Size should be empty as nodes should be removed", 0, context.nodesPendingStartup.size());
+	}
+
+	@Test
+	public void nodesDontClear() {
+		ScaleCapacityContext context = new ScaleCapacityContext();
+		AutomationDynamicNode firstNode = new AutomationDynamicNode(null, "foo", null, null, new Date(), 1);
+		AutomationDynamicNode secondNode = new AutomationDynamicNode(null, "bar", null, null, new Date(), 1);
+		context.addAll(Lists.newArrayList(firstNode, secondNode));
+		Assert.assertEquals("Size should be correct as nodes should exist in context", 2, context.nodesPendingStartup.size());
+		AutomationContext.getContext().addPendingNode(firstNode);
+		AutomationContext.getContext().addPendingNode(secondNode);
+		context.clearPendingNodes();
+		Assert.assertEquals("Size should be the same as nodes should exist in context", 2, context.nodesPendingStartup.size());
+	}
+
+}


### PR DESCRIPTION
The 'ad-hoc' scale logic would basically block additional scaling logic until the previous scaled nodes came online.  This had efficiency issues, especially when dealing with windows nodes that take ~10 minutes to come online, so I refactored the logic to just subtract pending load from the current load and continuously perform 'ad-hoc' scaling logic.